### PR TITLE
Add room service, init room routine

### DIFF
--- a/lib/expose/commands.js
+++ b/lib/expose/commands.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = (server, options) => ({
+    value: {
+        getRooms: {
+            description: '[no input]',
+            command: async (srv, []) => {
+
+                const { roomService } = server.services();
+
+                console.log('rooms\n');
+                console.log(JSON.stringify(roomService.getRooms()));
+            }
+        }
+    }
+});

--- a/lib/routes/route-name.js
+++ b/lib/routes/route-name.js
@@ -17,7 +17,6 @@ Dataz.prototype.addClientId = function (id) {
   this.clientIDs.push(id);
 };
 
-
 module.exports = {
     method: 'GET',
     path: '/tacos',

--- a/lib/services/room.js
+++ b/lib/services/room.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const Schmervice = require('@hapipal/schmervice');
+const Bounce = require('@hapi/bounce');
+const { v4: uuidv4 } = require('uuid');
+const { asyncStorageInternals } = require('@hapipal/toys');
+
+const DEFAULT_ROOMS = {
+    'tacos-and-friends': {
+        // Specifying the id here again
+        // helps us give a generic string
+        // to nes for broacasting to rooms
+        // this.server.subscription('/room/{id}');
+        id: 'tacos-and-friends',
+        name: 'Tacos and Friends',
+        users: []
+    }
+};
+
+module.exports = class RoomService extends Schmervice.Service {
+
+    initialize() {
+
+        // Use 'initRooms' to initialize the RoomService with data
+        let { initRooms } = this.options;
+
+        try {
+            initRooms = JSON.parse(initRooms);
+        }
+        catch (parseErr) {
+            Bounce.ignore(parseErr, SyntaxError);
+            initRooms = null;
+        }
+
+        this.rooms = initRooms || DEFAULT_ROOMS;
+
+        // When using 'this.server.publish' later, we'll pass the
+        // room id and nes will publish to the correct room.
+        // Ex:
+        // this.server.publish(
+        //     '/room/tacos-and-friends',
+        //     { id: 'tacos-and-friends', user: { id: 'xyz', ... } }
+        // );
+        this.server.subscription('/room/{id}');
+    }
+
+    // Use 'isPartial' to update with less info over the wire
+    upsertUserInRoom({ roomId, userInfo, isPartial }) {
+
+        this.assertRoomExists(roomId);
+
+        // User exists in room already — just override
+        if (userInfo.id && this.rooms[roomId].users[userId]) {
+            if (isPartial) {
+                this.rooms[roomId].users[userId] = {
+                    ...this.rooms[roomId].users[userId],
+                    ...userInfo
+                };
+            }
+            else {
+                this.rooms[roomId].users[userId] = { ...userInfo };
+            }
+        }
+        // User is new — gen id and add to room
+        else {
+            const userId = uuidv4();
+            this.rooms[roomId].users[userId] = { ...userInfo };
+        }
+
+        // Broadcast new user to all room listeners
+        this.broadcastState(roomId);
+    }
+
+    broadcastRoomState(roomId) {
+
+        this.assertRoomExists(roomId);
+
+        // Publish all room info to each client
+        this.server.publish(`/room/${roomId}`, this.room[roomId]);
+    }
+
+    getRooms() {
+
+        return this.rooms;
+    }
+
+    assertRoomExists(roomId) {
+
+        if (!this.rooms[roomId]) {
+            throw new Error('Room not found');
+        }
+    }
+};

--- a/lib/services/socket.js
+++ b/lib/services/socket.js
@@ -1,5 +1,0 @@
-'use strict';
-
-const Schmervice = require('@hapipal/schmervice');
-
-module.exports = class ServiceName extends Schmervice.Service {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -355,16 +355,6 @@
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/hoek": "9.x.x"
-      },
-      "dependencies": {
-        "@hapi/boom": {
-          "version": "9.1.3",
-          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.3.tgz",
-          "integrity": "sha512-RlrGyZ603hE/eRTZtTltocRm50HHmrmL3kGOP0SQ9MasazlW1mt/fkv4C5P/6rnpFXjwld/POFX1C8tMZE3ldg==",
-          "requires": {
-            "@hapi/hoek": "9.x.x"
-          }
-        }
       }
     },
     "@hapi/bourne": {
@@ -2445,6 +2435,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
   },
   "dependencies": {
     "@hapi/boom": "9.x.x",
+    "@hapi/bounce": "^2.0.0",
     "@hapi/nes": "^12.0.4",
     "@hapipal/haute-couture": "^4.1.0",
     "@hapipal/schmervice": "^2.0.0",
-    "joi": "17.x.x"
+    "joi": "17.x.x",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@hapi/code": "8.x.x",

--- a/server/manifest.js
+++ b/server/manifest.js
@@ -31,7 +31,10 @@ module.exports = new Confidence.Store({
         plugins: [
             {
                 plugin: '../lib', // Main plugin
-                options: {}
+                options: {
+                    // Use this to initialize the RoomService with data
+                    initRooms: process.env.INIT_ROOMS
+                }
             },
             {
                 plugin: {


### PR DESCRIPTION
### Changes
- Add room service
- Add a way to initiate the server with room state — here I was imagining a situation where we had to change the server in the middle of a session happening — and how we could do that. We could initiate a downtime mode for all users, for less than a minute probly, then kick out the state, add it to the other server as a stringified json object in an environment variable, and repoint the domain.
  - On Nearpeer I've been looking into a downtime routine so that's why

- Anyways, introduce the CLI portion of this setup where you can now run `hpal run zzz:get-rooms` to get a stringified value of the rooms held in the room service

- Run npm install after merging to install the new stuff